### PR TITLE
feat: perfil expandend

### DIFF
--- a/src/main/java/com/acme/vocatio/controller/UserProfileController.java
+++ b/src/main/java/com/acme/vocatio/controller/UserProfileController.java
@@ -1,0 +1,39 @@
+package com.acme.vocatio.controller;
+
+import com.acme.vocatio.dto.profile.ProfileDto;
+import com.acme.vocatio.dto.profile.ProfileUpdateRequest;
+import com.acme.vocatio.dto.profile.ProfileUpdateResponse;
+import com.acme.vocatio.security.UserPrincipal;
+import com.acme.vocatio.service.UserProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Endpoints del perfil del usuario autenticado. */
+@RestController
+@RequestMapping("/users/me")
+@RequiredArgsConstructor
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+
+    /** Recupera el perfil del usuario logueado. */
+    @GetMapping
+    public ProfileDto getCurrentUserProfile(@AuthenticationPrincipal UserPrincipal principal) {
+        return userProfileService.getCurrentUserProfile(principal.getUser().getId());
+    }
+
+    /** Actualiza edad, grado e intereses del usuario. */
+    @PutMapping
+    public ResponseEntity<ProfileUpdateResponse> updateCurrentUserProfile(
+            @AuthenticationPrincipal UserPrincipal principal, @Valid @RequestBody ProfileUpdateRequest request) {
+        ProfileDto updatedProfile = userProfileService.updateCurrentUserProfile(principal.getUser().getId(), request);
+        return ResponseEntity.ok(new ProfileUpdateResponse("Perfil actualizado", updatedProfile));
+    }
+}

--- a/src/main/java/com/acme/vocatio/dto/profile/ProfileDto.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/ProfileDto.java
@@ -1,0 +1,12 @@
+package com.acme.vocatio.dto.profile;
+
+import java.util.List;
+
+/** Vista consolidada del perfil personal. */
+public record ProfileDto(
+        Long id,
+        String email,
+        Integer age,
+        String grade,
+        String gradeLabel,
+        List<String> interests) {}

--- a/src/main/java/com/acme/vocatio/dto/profile/ProfileUpdateRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/ProfileUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.acme.vocatio.dto.profile;
+
+import com.acme.vocatio.validation.ValidAcademicGrade;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/** Campos permitidos para actualizar el perfil. */
+public record ProfileUpdateRequest(
+        @NotNull(message = "La edad es obligatoria")
+                @Min(value = 13, message = "La edad debe estar entre 13 y 30 años")
+                @Max(value = 30, message = "La edad debe estar entre 13 y 30 años")
+                Integer age,
+
+        @NotBlank(message = "El grado académico es obligatorio")
+                @ValidAcademicGrade
+                String grade,
+
+        @NotEmpty(message = "Selecciona al menos un interés")
+                List<@NotBlank(message = "El interés no puede estar vacío") String> interests) {}

--- a/src/main/java/com/acme/vocatio/dto/profile/ProfileUpdateResponse.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/ProfileUpdateResponse.java
@@ -1,0 +1,4 @@
+package com.acme.vocatio.dto.profile;
+
+/** Respuesta simple al actualizar el perfil. */
+public record ProfileUpdateResponse(String message, ProfileDto profile) {}

--- a/src/main/java/com/acme/vocatio/exception/UserNotFoundException.java
+++ b/src/main/java/com/acme/vocatio/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.acme.vocatio.exception;
+
+/** Se lanza cuando no existe el usuario solicitado. */
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException(Long userId) {
+        super("Usuario con id " + userId + " no encontrado");
+    }
+}

--- a/src/main/java/com/acme/vocatio/model/AcademicGrade.java
+++ b/src/main/java/com/acme/vocatio/model/AcademicGrade.java
@@ -1,0 +1,48 @@
+package com.acme.vocatio.model;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/** Catálogo alineado con la estructura educativa peruana. */
+public enum AcademicGrade {
+
+    SECUNDARIA_1("1° de secundaria"),
+    SECUNDARIA_2("2° de secundaria"),
+    SECUNDARIA_3("3° de secundaria"),
+    SECUNDARIA_4("4° de secundaria"),
+    SECUNDARIA_5("5° de secundaria"),
+    SUPERIOR_TECNICA_1("1° ciclo de instituto técnico"),
+    SUPERIOR_TECNICA_2("2° ciclo de instituto técnico"),
+    SUPERIOR_TECNICA_3("3° ciclo de instituto técnico"),
+    SUPERIOR_TECNICA_4("4° ciclo de instituto técnico"),
+    SUPERIOR_TECNICA_5_MAS("5° ciclo o más de instituto técnico"),
+    UNIVERSIDAD_1("1° ciclo universitario"),
+    UNIVERSIDAD_2("2° ciclo universitario"),
+    UNIVERSIDAD_3("3° ciclo universitario"),
+    UNIVERSIDAD_4("4° ciclo universitario"),
+    UNIVERSIDAD_5("5° ciclo universitario"),
+    UNIVERSIDAD_6_MAS("6° ciclo o más universitario");
+
+    private final String displayName;
+
+    AcademicGrade(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return name();
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public static Optional<AcademicGrade> fromCode(String code) {
+        if (code == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(values())
+                .filter(grade -> grade.name().equalsIgnoreCase(code.trim()))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/acme/vocatio/model/Profile.java
+++ b/src/main/java/com/acme/vocatio/model/Profile.java
@@ -2,6 +2,8 @@ package com.acme.vocatio.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -12,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/** Entidad JPA del perfil individual. */
 @Entity
 @Table(name = "profiles")
 @Getter
@@ -32,7 +35,9 @@ public class Profile {
 
     private Short age;
 
-    private String grade;
+    @Enumerated(EnumType.STRING)
+    @Column(length = 64)
+    private AcademicGrade grade;
 
     @Column(name = "personal_interests", columnDefinition = "jsonb")
     private String personalInterests;

--- a/src/main/java/com/acme/vocatio/service/UserProfileService.java
+++ b/src/main/java/com/acme/vocatio/service/UserProfileService.java
@@ -1,0 +1,128 @@
+package com.acme.vocatio.service;
+
+import com.acme.vocatio.dto.profile.ProfileDto;
+import com.acme.vocatio.dto.profile.ProfileUpdateRequest;
+import com.acme.vocatio.exception.UserNotFoundException;
+import com.acme.vocatio.model.AcademicGrade;
+import com.acme.vocatio.model.Profile;
+import com.acme.vocatio.model.User;
+import com.acme.vocatio.repository.ProfileRepository;
+import com.acme.vocatio.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Orquesta la gestión del perfil actual. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserProfileService {
+
+    private static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<>() {};
+
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Devuelve el perfil del usuario autenticado. */
+    public ProfileDto getCurrentUserProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        Profile profile = profileRepository.findById(userId).orElse(null);
+        return toDto(user, profile);
+    }
+
+    /** Guarda los cambios de edad, grado e intereses. */
+    @Transactional
+    public ProfileDto updateCurrentUserProfile(Long userId, ProfileUpdateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+
+        Profile profile = profileRepository
+                .findById(userId)
+                .orElseGet(() -> {
+                    Profile newProfile = new Profile();
+                    newProfile.setId(userId);
+                    newProfile.setUser(user);
+                    return newProfile;
+                });
+
+        profile.setUser(user);
+        profile.setAge(request.age().shortValue());
+
+        AcademicGrade grade = AcademicGrade
+                .fromCode(request.grade())
+                .orElseThrow(() -> new IllegalStateException("Grado académico no reconocido"));
+        profile.setGrade(grade);
+
+        List<String> normalizedInterests = normalizeInterests(request.interests());
+        profile.setPersonalInterests(writeInterests(normalizedInterests));
+
+        Profile saved = profileRepository.save(profile);
+        return toDto(user, saved, normalizedInterests);
+    }
+
+    /** Limpia espacios y evita duplicados en intereses. */
+    private List<String> normalizeInterests(List<String> rawInterests) {
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String interest : rawInterests) {
+            String trimmed = interest == null ? "" : interest.trim();
+            if (!trimmed.isEmpty()) {
+                normalized.add(trimmed);
+            }
+        }
+        return List.copyOf(normalized);
+    }
+
+    /** Serializa los intereses a JSON. */
+    private String writeInterests(List<String> interests) {
+        try {
+            return objectMapper.writeValueAsString(interests);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("No fue posible guardar los intereses del perfil", ex);
+        }
+    }
+
+    /** Deserializa los intereses almacenados. */
+    private List<String> readInterests(String interestsJson) {
+        if (interestsJson == null || interestsJson.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(interestsJson, STRING_LIST_TYPE);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("No fue posible leer los intereses almacenados", ex);
+        }
+    }
+
+    /** Crea el DTO usando los datos existentes. */
+    private ProfileDto toDto(User user, Profile profile) {
+        List<String> interests = profile == null ? List.of() : readInterests(profile.getPersonalInterests());
+        return toDto(user, profile, interests);
+    }
+
+    /** Ajusta el DTO con edad, grado e intereses. */
+    private ProfileDto toDto(User user, Profile profile, List<String> interests) {
+        Integer age = null;
+        String gradeCode = null;
+        String gradeLabel = null;
+
+        if (profile != null) {
+            if (profile.getAge() != null) {
+                age = profile.getAge().intValue();
+            }
+            if (profile.getGrade() != null) {
+                gradeCode = profile.getGrade().getCode();
+                gradeLabel = profile.getGrade().getDisplayName();
+            }
+        }
+
+        List<String> safeInterests = interests == null ? List.of() : List.copyOf(interests);
+
+        return new ProfileDto(user.getId(), user.getEmail(), age, gradeCode, gradeLabel, safeInterests);
+    }
+}

--- a/src/main/java/com/acme/vocatio/validation/ValidAcademicGrade.java
+++ b/src/main/java/com/acme/vocatio/validation/ValidAcademicGrade.java
@@ -1,0 +1,26 @@
+package com.acme.vocatio.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/** Verifica que el grado exista en el catálogo peruano. */
+@Documented
+@Constraint(validatedBy = ValidAcademicGradeValidator.class)
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+public @interface ValidAcademicGrade {
+
+    String message() default "El grado académico no es válido";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/acme/vocatio/validation/ValidAcademicGradeValidator.java
+++ b/src/main/java/com/acme/vocatio/validation/ValidAcademicGradeValidator.java
@@ -1,0 +1,17 @@
+package com.acme.vocatio.validation;
+
+import com.acme.vocatio.model.AcademicGrade;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/** Revisa que el código recibido corresponda a un grado válido. */
+public class ValidAcademicGradeValidator implements ConstraintValidator<ValidAcademicGrade, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return AcademicGrade.fromCode(value).isPresent();
+    }
+}

--- a/src/main/java/com/acme/vocatio/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/acme/vocatio/web/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.acme.vocatio.web;
 
 import com.acme.vocatio.exception.DuplicateEmailException;
 import com.acme.vocatio.exception.InvalidCredentialsException;
+import com.acme.vocatio.exception.UserNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.List;
@@ -14,9 +15,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/** Maneja errores comunes de la API. */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /** Devuelve errores de validación de payloads. */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidationErrors(MethodArgumentNotValidException ex) {
         Map<String, List<String>> errors = ex.getBindingResult()
@@ -31,6 +34,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(body);
     }
 
+    /** Convierte violaciones a una respuesta legible. */
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Map<String, Object>> handleConstraintViolations(ConstraintViolationException ex) {
         Map<String, Object> body = new HashMap<>();
@@ -44,6 +48,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(body);
     }
 
+    /** Ofrece sugerencias cuando el correo ya existe. */
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<Map<String, Object>> handleDuplicateEmail(DuplicateEmailException ex) {
         Map<String, Object> body = new HashMap<>();
@@ -54,10 +59,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
     }
 
+    /** Informa credenciales inválidas. */
     @ExceptionHandler(InvalidCredentialsException.class)
     public ResponseEntity<Map<String, Object>> handleInvalidCredentials(InvalidCredentialsException ex) {
         Map<String, Object> body = new HashMap<>();
         body.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    /** Avisa cuando no se encontró al usuario. */
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleUserNotFound(UserNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
     }
 }

--- a/src/test/java/com/acme/vocatio/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/acme/vocatio/controller/UserProfileControllerTest.java
@@ -1,0 +1,195 @@
+package com.acme.vocatio.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Pruebas del flujo GET/PUT del perfil. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldReturnEmptyProfileWhenNoData() throws Exception {
+        String email = "empty-profile@vocatio.com";
+        String token = obtainAccessToken(email);
+
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.age").value(nullValue()))
+                .andExpect(jsonPath("$.grade").value(nullValue()))
+                .andExpect(jsonPath("$.gradeLabel").value(nullValue()))
+                .andExpect(jsonPath("$.interests", hasSize(0)));
+    }
+
+    @Test
+    void shouldUpdateProfile() throws Exception {
+        String email = "update-profile@vocatio.com";
+        String token = obtainAccessToken(email);
+
+        mockMvc.perform(put("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "age": 18,
+                                  "grade": "SUPERIOR_TECNICA_2",
+                                  "interests": [
+                                    "Tecnología",
+                                    "Arte"
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Perfil actualizado"))
+                .andExpect(jsonPath("$.profile.email").value(email))
+                .andExpect(jsonPath("$.profile.age").value(18))
+                .andExpect(jsonPath("$.profile.grade").value("SUPERIOR_TECNICA_2"))
+                .andExpect(jsonPath("$.profile.gradeLabel").value("2° ciclo de instituto técnico"))
+                .andExpect(jsonPath("$.profile.interests", contains("Tecnología", "Arte")));
+
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.age").value(18))
+                .andExpect(jsonPath("$.grade").value("SUPERIOR_TECNICA_2"))
+                .andExpect(jsonPath("$.interests", contains("Tecnología", "Arte")));
+    }
+
+    @Test
+    void shouldRejectAgeOutsideRange() throws Exception {
+        String token = obtainAccessToken("invalid-age@vocatio.com");
+
+        mockMvc.perform(put("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "age": 12,
+                                  "grade": "SECUNDARIA_3",
+                                  "interests": ["Tecnología"]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.age[0]").value("La edad debe estar entre 13 y 30 años"));
+    }
+
+    @Test
+    void shouldRejectInvalidGrade() throws Exception {
+        String token = obtainAccessToken("invalid-grade@vocatio.com");
+
+        mockMvc.perform(put("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "age": 18,
+                                  "grade": "UNIVERSIDAD_10",
+                                  "interests": ["Tecnología"]
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.grade[0]").value("El grado académico no es válido"));
+    }
+
+    @Test
+    void shouldRejectEmptyInterests() throws Exception {
+        String token = obtainAccessToken("empty-interests@vocatio.com");
+
+        mockMvc.perform(put("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "age": 18,
+                                  "grade": "SECUNDARIA_4",
+                                  "interests": []
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.interests[0]").value("Selecciona al menos un interés"));
+    }
+
+    @Test
+    void shouldNormalizeAndDeduplicateInterests() throws Exception {
+        String token = obtainAccessToken("normalize@vocatio.com");
+
+        mockMvc.perform(put("/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "age": 20,
+                                  "grade": "universidad_3",
+                                  "interests": [
+                                    "  Tecnología  ",
+                                    "Arte",
+                                    "Tecnología",
+                                    "Arte"
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profile.grade").value("UNIVERSIDAD_3"))
+                .andExpect(jsonPath("$.profile.interests", contains("Tecnología", "Arte")));
+    }
+
+    /** Registra y autentica un usuario de prueba. */
+    private String obtainAccessToken(String email) throws Exception {
+        register(email);
+        String response = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "Password1"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode node = objectMapper.readTree(response);
+        return node.path("tokens").path("accessToken").asText();
+    }
+
+    /** Crea el usuario de apoyo para las pruebas. */
+    private void register(String email) throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "%s",
+                                  "password": "Password1"
+                                }
+                                """.formatted(email)))
+                .andExpect(status().isCreated());
+    }
+}


### PR DESCRIPTION
Este PR agrega la gestión de perfiles de usuario, permitiendo que los usuarios autenticados vean y actualicen su información (edad, grado académico e intereses). También introduce validaciones, manejo de excepciones y un catálogo de grados académicos alineado con el sistema educativo peruano.

###  Cambios principales

* **Controlador y servicio de perfil**: Endpoints para ver/editar perfil del usuario, normalización de intereses y conversión entre entidades/DTOs.
* **Manejo de errores**: Nueva excepción `UserNotFoundException` y respuestas más claras ante errores comunes (validación, credenciales inválidas, usuario no encontrado).
* **Catálogo académico**: Enum `AcademicGrade` en vez de strings, más una anotación `ValidAcademicGrade` para validar entradas.
