### PR TITLE
M3-01: Listado de carreras implementado

### DIFF
--- a/src/main/java/com/acme/vocatio/controller/CareerController.java
+++ b/src/main/java/com/acme/vocatio/controller/CareerController.java
@@ -1,0 +1,39 @@
+package com.acme.vocatio.controller;
+
+import com.acme.vocatio.dto.career.CareerListDto;
+import com.acme.vocatio.service.CareerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controlador para explorar las carreras disponibles.
+ * Caso de uso: M3-01 - Listar fichas de carrera.
+ */
+@RestController
+@RequestMapping("/api/careers") // convención: agregar /api para endpoints REST
+@RequiredArgsConstructor
+public class CareerController {
+
+    private final CareerService careerService;
+
+    /**
+     * Endpoint: GET /api/careers
+     * Devuelve una lista paginada de fichas de carrera (nombre, duración, modalidad, descripción).
+     */
+    @GetMapping
+    public ResponseEntity<Page<CareerListDto>> listCareers(Pageable pageable) {
+        Page<CareerListDto> careers = careerService.listCareers(pageable);
+
+        if (careers.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(careers);
+    }
+
+}

--- a/src/main/java/com/acme/vocatio/dto/career/CareerListDto.java
+++ b/src/main/java/com/acme/vocatio/dto/career/CareerListDto.java
@@ -1,0 +1,13 @@
+package com.acme.vocatio.dto.career;
+
+/**
+ * DTO para representar la informacion basica de una carrera al listar.
+ * Caso de uso: M3-01.
+ */
+public record CareerListDto(
+        Long id,
+        String nombre,
+        String duracion,
+        String modalidad,
+        String descripcion
+) {}

--- a/src/main/java/com/acme/vocatio/model/Career.java
+++ b/src/main/java/com/acme/vocatio/model/Career.java
@@ -1,0 +1,31 @@
+package com.acme.vocatio.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Entidad JPA que representa una carrera. */
+@Entity
+@Table(name = "careers")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Career {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String nombre;
+
+    @Column(nullable = false, length = 50)
+    private String duracion;
+
+    @Column(nullable = false, length = 50)
+    private String modalidad;
+
+    @Column(columnDefinition = "TEXT")
+    private String descripcion;
+}

--- a/src/main/java/com/acme/vocatio/repository/CareerRepository.java
+++ b/src/main/java/com/acme/vocatio/repository/CareerRepository.java
@@ -1,0 +1,11 @@
+package com.acme.vocatio.repository;
+
+import com.acme.vocatio.model.Career;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Repositorio JPA para la entidad Career. */
+@Repository
+public interface CareerRepository extends JpaRepository<Career, Long> {
+    // Para M3-01 no necesitamos consultas adicionales todavía
+}

--- a/src/main/java/com/acme/vocatio/service/CareerService.java
+++ b/src/main/java/com/acme/vocatio/service/CareerService.java
@@ -1,0 +1,36 @@
+package com.acme.vocatio.service;
+
+import com.acme.vocatio.dto.career.CareerListDto;
+import com.acme.vocatio.model.Career;
+import com.acme.vocatio.repository.CareerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Servicio para operaciones de carreras. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CareerService {
+
+    private final CareerRepository careerRepository;
+
+    /** Devuelve una pagina de carreras mapeadas a CareerListDto. */
+    public Page<CareerListDto> listCareers(Pageable pageable) {
+        return careerRepository.findAll(pageable)
+                .map(this::toDto);
+    }
+
+    /** Mapea entidad Career a DTO CareerListDto. */
+    private CareerListDto toDto(Career career) {
+        return new CareerListDto(
+                career.getId(),
+                career.getNombre(),
+                career.getDuracion(),
+                career.getModalidad(),
+                career.getDescripcion()
+        );
+    }
+}


### PR DESCRIPTION
Este PR implementa el módulo M3-01 para listar las fichas de carrera disponibles mostrando:

- Nombre
- Duración
- Modalidad
- Descripción

Incluye:

- CareerController con endpoint GET /api/careers
- CareerService con mapeo a DTO CareerListDto
- CareerRepository JPA
- Entidad Career y DTO CareerListDto
