### PR TITLE
Allow CORS preflight and configure global CORS

### DIFF
--- a/src/main/java/com/acme/vocatio/config/SecurityConfig.java
+++ b/src/main/java/com/acme/vocatio/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -17,6 +18,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 // 👇 Importante: MvcRequestMatcher + Introspector
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
@@ -39,7 +43,7 @@ public class SecurityConfig {
 
         http
                 .csrf(csrf -> csrf.disable())
-                .cors(cors -> {})
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // ✅ Públicos SIN /api/v1: MvcRequestMatcher los adapta
@@ -53,6 +57,7 @@ public class SecurityConfig {
                                 mvc.pattern("/webjars/**"),
                                 mvc.pattern("/actuator/health")
                         ).permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(
@@ -80,5 +85,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        var configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(java.util.List.of("*"));
+        configuration.setAllowedMethods(java.util.List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(java.util.List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
Actualiza `SecurityConfig.java` para CORS y endpoints públicos.

* Añade `corsConfigurationSource` con orígenes, métodos, headers y credenciales; se aplica a todas las rutas.
* El `SecurityFilterChain` usa esa config y **permite OPTIONS** global (preflight CORS).
* Se agregan imports requeridos: `CorsConfiguration`, `CorsConfigurationSource`, `UrlBasedCorsConfigurationSource`, `HttpMethod`.
