### PR TITLE
m3-02: implementar filtros dinámicos por área, duración y tipo de formación

### DIFF
--- a/src/main/java/com/acme/vocatio/controller/CareerController.java
+++ b/src/main/java/com/acme/vocatio/controller/CareerController.java
@@ -6,25 +6,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * Controlador para explorar las carreras disponibles.
- * Caso de uso: M3-01 - Listar fichas de carrera.
+ * Casos de uso: M3-01 (listar) y M3-02 (filtrar).
  */
 @RestController
-@RequestMapping("/api/careers") // convención: agregar /api para endpoints REST
+@RequestMapping("/api/careers")
 @RequiredArgsConstructor
 public class CareerController {
 
     private final CareerService careerService;
 
-    /**
-     * Endpoint: GET /api/careers
-     * Devuelve una lista paginada de fichas de carrera (nombre, duración, modalidad, descripción).
-     */
+    /** Endpoint: GET /api/careers - Lista paginada (M3-01). */
     @GetMapping
     public ResponseEntity<Page<CareerListDto>> listCareers(Pageable pageable) {
         Page<CareerListDto> careers = careerService.listCareers(pageable);
@@ -36,4 +33,19 @@ public class CareerController {
         return ResponseEntity.ok(careers);
     }
 
+    /** Endpoint: GET /api/careers/filter - Filtrado por área, duración y tipo (M3-02). */
+    @GetMapping("/filter")
+    public ResponseEntity<List<CareerListDto>> filterCareers(
+            @RequestParam(required = false) String area,
+            @RequestParam(required = false) String duracion,
+            @RequestParam(required = false) String tipoFormacion) {
+
+        List<CareerListDto> careers = careerService.filterCareers(area, duracion, tipoFormacion);
+
+        if (careers.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(careers);
+    }
 }

--- a/src/main/java/com/acme/vocatio/dto/career/CareerListDto.java
+++ b/src/main/java/com/acme/vocatio/dto/career/CareerListDto.java
@@ -1,13 +1,14 @@
 package com.acme.vocatio.dto.career;
 
 /**
- * DTO para representar la informacion basica de una carrera al listar.
- * Caso de uso: M3-01.
+ * DTO para representar la información básica de una carrera al listar.
+ * Incluye campos opcionales para filtros futuros.
  */
 public record CareerListDto(
         Long id,
         String nombre,
-        String duracion,
-        String modalidad,
-        String descripcion
+        String descripcion,
+        String perfilRequerido,
+
+        String modalidad //opcional
 ) {}

--- a/src/main/java/com/acme/vocatio/model/Career.java
+++ b/src/main/java/com/acme/vocatio/model/Career.java
@@ -5,9 +5,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/** Entidad JPA que representa una carrera. */
+/**
+ * Entidad JPA que representa una carrera.
+ * Mapeada a la tabla Carrera existente en la base de datos.
+ */
 @Entity
-@Table(name = "careers")
+@Table(name = "Carrera")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -15,17 +18,28 @@ public class Career {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_carrera")
     private Long id;
 
-    @Column(nullable = false, length = 150)
+    @Column(name = "nombre_carrera", nullable = false, length = 150)
     private String nombre;
 
-    @Column(nullable = false, length = 50)
-    private String duracion;
-
-    @Column(nullable = false, length = 50)
-    private String modalidad;
-
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "descripcion_detallada", columnDefinition = "TEXT")
     private String descripcion;
+
+    @Column(name = "perfil_requerido", columnDefinition = "TEXT")
+    private String perfilRequerido;
+
+    // Campos opcionales para filtros futuros
+    @Column(length = 50)
+    private String duracion;      // Ej: "3 años", "5 años"
+
+    @Column(length = 50)
+    private String modalidad;     // Ej: "Presencial", "Virtual"
+
+    @Column(length = 100)
+    private String areaInteres;   // Ej: "Ingeniería", "Salud"
+
+    @Column(length = 50)
+    private String tipoFormacion; // Ej: "Técnica", "Universitaria"
 }

--- a/src/main/java/com/acme/vocatio/repository/CareerRepository.java
+++ b/src/main/java/com/acme/vocatio/repository/CareerRepository.java
@@ -4,8 +4,33 @@ import com.acme.vocatio.model.Career;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-/** Repositorio JPA para la entidad Career. */
+import java.util.List;
+
+/**
+ * Repositorio JPA para la entidad Career.
+ * Incluye métodos para filtros dinámicos según diferentes combinaciones de campos.
+ */
 @Repository
 public interface CareerRepository extends JpaRepository<Career, Long> {
-    // Para M3-01 no necesitamos consultas adicionales todavía
+
+    // ----------------------------
+    // Filtros por un solo campo
+    // ----------------------------
+    List<Career> findByAreaInteres(String areaInteres);
+
+    // ----------------------------
+    // Filtros por combinaciones de campos
+    // ----------------------------
+    List<Career> findByDuracionAndTipoFormacion(String duracion, String tipoFormacion);
+
+    List<Career> findByAreaInteresAndDuracionAndTipoFormacion(String areaInteres, String duracion, String tipoFormacion);
+
+    // ----------------------------
+    // Filtros (4 campos)
+    // ----------------------------
+    List<Career> findByAreaInteresAndDuracionAndModalidadAndTipoFormacion(
+            String areaInteres, String duracion, String modalidad, String tipoFormacion);
+
+    List<Career> findByDuracionAndModalidadAndTipoFormacion(
+            String duracion, String modalidad, String tipoFormacion);
 }

--- a/src/main/java/com/acme/vocatio/service/CareerService.java
+++ b/src/main/java/com/acme/vocatio/service/CareerService.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /** Servicio para operaciones de carreras. */
 @Service
 @RequiredArgsConstructor
@@ -17,10 +19,27 @@ public class CareerService {
 
     private final CareerRepository careerRepository;
 
-    /** Devuelve una pagina de carreras mapeadas a CareerListDto. */
+    /** Devuelve una página de carreras mapeadas a CareerListDto (M3-01). */
     public Page<CareerListDto> listCareers(Pageable pageable) {
         return careerRepository.findAll(pageable)
                 .map(this::toDto);
+    }
+
+    /** Filtra carreras por área, duración y tipo de formación (M3-02). */
+    public List<CareerListDto> filterCareers(String area, String duracion, String tipoFormacion) {
+        List<Career> careers;
+
+        if (area != null && duracion != null && tipoFormacion != null) {
+            careers = careerRepository.findByAreaInteresAndDuracionAndTipoFormacion(area, duracion, tipoFormacion);
+        } else if (duracion != null && tipoFormacion != null) {
+            careers = careerRepository.findByDuracionAndTipoFormacion(duracion, tipoFormacion);
+        } else if (area != null) {
+            careers = careerRepository.findByAreaInteres(area);
+        } else {
+            careers = careerRepository.findAll();
+        }
+
+        return careers.stream().map(this::toDto).toList();
     }
 
     /** Mapea entidad Career a DTO CareerListDto. */
@@ -28,9 +47,9 @@ public class CareerService {
         return new CareerListDto(
                 career.getId(),
                 career.getNombre(),
-                career.getDuracion(),
-                career.getModalidad(),
-                career.getDescripcion()
+                career.getDescripcion(),
+                career.getPerfilRequerido(),
+                career.getAreaInteres()
         );
     }
 }


### PR DESCRIPTION
Este Pull Request implementa la funcionalidad de filtrado de carreras (M3-02) en Vocatio.  

**Cambios principales:**
- Se agregan los campos `areaInteres` y `tipoFormacion` en la entidad Career.
- DTO `CareerListDto` actualizado para reflejar la información básica de la carrera.
- Repositorio `CareerRepository` con métodos para filtrar por:
  - Área de interés
  - Duración
  - Tipo de formación (Técnica / Universitaria)
- Servicio `CareerService` con la lógica de filtrado según distintas combinaciones de parámetros.
- Controller `CareerController` con endpoints:
  - `GET /api/careers` → lista paginada de carreras
  - `GET /api/careers/filter` → filtra carreras según parámetros opcionales (`area`, `duracion`, `tipoFormacion`)

**Objetivo:** permitir que la interfaz muestre filtros avanzados y mejorar la exploración de carreras para los usuarios.  

💡 Nota: Este PR se centra en la lógica backend; los cambios de UI se integrarán posteriormente.
